### PR TITLE
setup.py: move from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from distutils.core import setup
+from setuptools import setup
 
 requires = ['pyyaml']
 if float('%d.%d' % sys.version_info[:2]) < 2.7:


### PR DESCRIPTION
The distutils package got removed from python 3.12 and it seems the recommended upgrade path is to just use setuptools instead.

This trivial commit does exactly this.